### PR TITLE
Add group by mapping support

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -78,6 +78,29 @@ trait Mappable
     }
 
     /**
+     * Custom group by to group by mapped attributes
+     *
+     * @param \Sofa\Eloquence\Builder $query
+     * @param \Sofa\Hookable\Contracts\ArgumentBag $args
+     * @return void
+     */
+    protected function mappedGroupBy(Builder $query, ArgumentBag $args)
+    {
+        $groupArgs = $args->get('groups');
+        $groups = \is_array($groupArgs[0]) ? $groupArgs[0] : $groupArgs;
+
+        foreach ($groups as $key => $group) {
+            if ($this->hasMapping($group)) {
+                $mapping = $this->getMappingForAttribute($group);
+
+                $groups[$key] = $mapping;
+            }
+        }
+
+        $args->set('groups', $groups);
+    }
+
+    /**
      * Adjust mapped columns for select statement.
      *
      * @param  \Sofa\Eloquence\Builder $query

--- a/src/Mappable/Hooks.php
+++ b/src/Mappable/Hooks.php
@@ -32,6 +32,10 @@ class Hooks
                 call_user_func_array([$this, 'mappedSelect'], [$query, $args]);
             }
 
+            if ($method === 'groupBy') {
+              call_user_func_array([$this, 'mappedGroupBy'], [$query, $args]);
+            }
+
             return $next($query, $bag);
         };
     }


### PR DESCRIPTION
This adds support for translating column names when they are used in a groupBy call.

Related PRs:
Hookable: `https://github.com/jarektkaczyk/hookable/pull/21`
Mappable: `https://github.com/jarektkaczyk/eloquence-mappable/pull/3`