### PR TITLE
Support for Laravel 5.8+ getQualifiedForeignKey renamed to getQualifi…

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -318,7 +318,7 @@ trait Mappable
         }
 
         if ($relation instanceof BelongsTo && !$relation instanceof MorphTo) {
-            return [$relation->getQualifiedForeignKey(), $relation->getQualifiedOwnerKeyName()];
+            return [$relation->getQualifiedForeignKeyName(), $relation->getQualifiedOwnerKeyName()];
         }
 
         $class = get_class($relation);


### PR DESCRIPTION
Support for Laravel 5.8+ getQualifiedForeignKey renamed to getQualifiedForeignKeyName as per the documentation: https://laravel.com/docs/5.8/upgrade\#eloquent